### PR TITLE
chore(release): pulling release/1.0.1 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [1.0.1](https://github.com/rudderlabs/crash-reporter-ios/compare/v1.0.0...v1.0.1) (2023-11-28)
+
+
+### Bug Fixes
+
+* defined modules for RSCrashReporter as it is a objectice-c pod ([93a305f](https://github.com/rudderlabs/crash-reporter-ios/commit/93a305fe21ee716397186a5a3bb2dc2a04fc60ac))

--- a/RSCrashReporter.podspec
+++ b/RSCrashReporter.podspec
@@ -24,6 +24,7 @@ Pod::Spec.new do |s|
   s.swift_versions = ['5.0']
   s.requires_arc = true
   s.prefix_header_file = false
+  s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
   s.compiler_flags = [ "-fvisibility=hidden" ]
   
   s.source_files = 'RSCrashReporter/**/*.{m,h,mm,c}'

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,7 @@ sonar.qualitygate.wait=false
 sonar.projectKey=rudderlabs_crash-reporter-ios
 sonar.organization=rudderlabs
 sonar.projectName=Crash Reporter iOS
-sonar.projectVersion=1.0.0
+sonar.projectVersion=1.0.1
 
 # C/C++/Objective-C related details
 # sonar.cfamily.compile-commands=compile_commands.json


### PR DESCRIPTION
:crown: *An automated PR*

   Unreleased (2023-11-28)<br> * fix: defined modules for RSCrashReporter as it is a objectice-c pod ([93a305f](https://github.com/rudderlabs/crash-reporter-ios/commit/93a305f))<br> * chore: fix podspec ( 2) ([d1603dc](https://github.com/rudderlabs/crash-reporter-ios/commit/d1603dc)), closes [ 2](https://github.com/rudderlabs/crash-reporter-ios/issues/2)<br> * chore: update README.md ( 4) ([5d4b473](https://github.com/rudderlabs/crash-reporter-ios/commit/5d4b473)), closes [ 4](https://github.com/rudderlabs/crash-reporter-ios/issues/4)<br> * chore: update README.md ( 5) ([e1b6a56](https://github.com/rudderlabs/crash-reporter-ios/commit/e1b6a56)), closes [ 5](https://github.com/rudderlabs/crash-reporter-ios/issues/5)