### PR TITLE
fix: defined modules for RSCrashReporter as it is a objective-c pod

### DIFF
--- a/RSCrashReporter.podspec
+++ b/RSCrashReporter.podspec
@@ -24,6 +24,7 @@ Pod::Spec.new do |s|
   s.swift_versions = ['5.0']
   s.requires_arc = true
   s.prefix_header_file = false
+  s.pod_target_xcconfig = { "DEFINES_MODULE" => "YES" }
   s.compiler_flags = [ "-fvisibility=hidden" ]
   
   s.source_files = 'RSCrashReporter/**/*.{m,h,mm,c}'


### PR DESCRIPTION
# Description

defined modules for RSCrashReporter as it is a objective-c pod
