### PR TITLE
chore(ci): migrate all workflows from PAT to GITHUB_TOKEN/App Token [SEC-58]

### DIFF
--- a/.github/workflows/draft-new-beta-release.yml
+++ b/.github/workflows/draft-new-beta-release.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   draft-new-beta-release:
     permissions:
-      contents: write  # for Git to git push
+      contents: read # GITHUB_TOKEN only needs read access
     name: Draft a new Beta release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/fix/') || startsWith(github.ref, 'refs/heads/feat/')
@@ -23,10 +23,19 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and push changes
+
       - name: Checkout source branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set Node 16
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
@@ -36,6 +45,8 @@ jobs:
       # In order to make a commit, we need to initialize a user.
       # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
       - name: Initialize mandatory git config
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           git config user.name "GitHub actions"
           git config user.email noreply@github.com
@@ -45,6 +56,8 @@ jobs:
         id: create-release
         env:
           HUSKY: 0
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          BETA_VERSION: ${{ github.event.inputs.beta_version }}
         run: |
           source_branch_name=${GITHUB_REF##*/}
           release_type=beta-release
@@ -54,7 +67,7 @@ jobs:
           current_version=$(jq -r .version package.json)
           
           npx standard-version --skip.commit --skip.tag --skip.changelog
-          new_version="$(jq -r .version package.json).beta.${{ github.event.inputs.beta_version }}"
+          new_version="$(jq -r .version package.json).beta.${BETA_VERSION}"
           git reset --hard
 
           branch_name="${release_type}/${new_version}"
@@ -81,13 +94,15 @@ jobs:
           echo "Current version: $CURRENT_VERSION_VALUE"
           echo "New version: $NEW_VERSION_VALUE"
           npx replace $CURRENT_VERSION_VALUE $NEW_VERSION_VALUE package.json
-          git add package.json
           echo ${{ steps.create-release.outputs.new_version }}
-          echo "commit_summary=$SUMMARY" >> $GITHUB_OUTPUT
-          git commit -m "chore(beta-relase): $NEW_VERSION_VALUE"
-          git tag -a "v$NEW_VERSION_VALUE" -m "chore: release v$NEW_VERSION_VALUE"
-          git push origin "v$NEW_VERSION_VALUE"
 
-      - name: Push new version in release branch & tag
-        run: |
-          git push
+      - name: Create verified commit via API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(beta-release): v${{ steps.create-release.outputs.new_version }}'
+          files: |
+            package.json
+          tag: 'v${{ steps.create-release.outputs.new_version }}'

--- a/.github/workflows/draft-new-beta-release.yml
+++ b/.github/workflows/draft-new-beta-release.yml
@@ -41,15 +41,6 @@ jobs:
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 16
-          
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
 
       # Calculate the next release version based on conventional semantic release
       - name: Create release branch
@@ -65,7 +56,7 @@ jobs:
           git fetch --tags origin
           git merge origin/master
           current_version=$(jq -r .version package.json)
-          
+
           npx standard-version --skip.commit --skip.tag --skip.changelog
           new_version="$(jq -r .version package.json).beta.${BETA_VERSION}"
           git reset --hard
@@ -77,14 +68,22 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
-          
+
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
           echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
           echo "NEW_VERSION_VALUE=$new_version" >> $GITHUB_ENV
+
+      - name: Create release branch via API
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          BASE_SHA=$(git rev-parse HEAD)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
+            -f sha="$BASE_SHA"
 
       - name: Bump version
         id: finish-release

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -38,15 +38,6 @@ jobs:
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           node-version: 16
-          
-      # In order to make a commit, we need to initialize a user.
-      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
-      - name: Initialize mandatory git config
-        env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          git config user.name "GitHub actions"
-          git config user.email noreply@github.com
 
       # Calculate the next release version based on conventional semantic release
       - name: Create release branch
@@ -62,7 +53,7 @@ jobs:
           git fetch --tags origin
           git merge origin/master
           current_version=$(jq -r .version package.json)
-          
+
           npx standard-version --skip.commit --skip.tag --skip.changelog
           new_version=$(jq -r .version package.json)
           git reset --hard
@@ -74,14 +65,22 @@ jobs:
           echo "Release type is $release_type"
           echo "New version is $new_version"
           echo "New release branch name is $branch_name"
-          git checkout -b "$branch_name"
-          git push --set-upstream origin "$branch_name"
-          
+
           echo "source_branch_name=$source_branch_name" >> $GITHUB_OUTPUT
           echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
           echo "CURRENT_VERSION_VALUE=$current_version" >> $GITHUB_ENV
           echo "NEW_VERSION_VALUE=$new_version" >> $GITHUB_ENV
+
+      - name: Create release branch via API
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          BASE_SHA=$(git rev-parse HEAD)
+          gh api repos/${{ github.repository }}/git/refs \
+            --method POST \
+            -f ref="refs/heads/${{ steps.create-release.outputs.branch_name }}" \
+            -f sha="$BASE_SHA"
 
       - name: Update changelog & bump version
         id: finish-release

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   draft-new-release:
     permissions:
-      contents: write  # for Git to git push
+      contents: read # GITHUB_TOKEN only needs read access
     name: Draft a new release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/feat/') || startsWith(github.ref, 'refs/heads/fix/')
@@ -19,10 +19,20 @@ jobs:
         with:
           egress-policy: audit
 
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits and push changes
+          permission-pull-requests: write # to create and update PRs
+
       - name: Checkout source branch
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set Node 16
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
@@ -32,6 +42,8 @@ jobs:
       # In order to make a commit, we need to initialize a user.
       # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
       - name: Initialize mandatory git config
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           git config user.name "GitHub actions"
           git config user.email noreply@github.com
@@ -41,6 +53,7 @@ jobs:
         id: create-release
         env:
           HUSKY: 0
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           source_branch_name=${GITHUB_REF##*/}
           release_type=release
@@ -74,6 +87,7 @@ jobs:
         id: finish-release
         env:
           HUSKY: 0
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           npm i -g conventional-changelog-cli@2.2.2
           SUMMARY=$(((npx conventional-changelog -u) 2>&1) | sed "s/*/<br> */g" | sed "s/#/ /g" | tr -d '\n' || true)
@@ -87,6 +101,8 @@ jobs:
           npx standard-version -a --skip.tag
 
       - name: Push new version in release branch & tag
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           git push
 
@@ -95,7 +111,7 @@ jobs:
         with:
           source_branch: ${{ steps.create-release.outputs.branch_name }}
           destination_branch: 'master'
-          github_token: ${{ secrets.PAT }}
+          github_token: ${{ steps.generate-token.outputs.token }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body: ":crown: *An automated PR*\n\n${{ steps.finish-release.outputs.commit_summary }}"
           pr_reviewer: 'pallabmaiti'

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -87,7 +87,6 @@ jobs:
         id: finish-release
         env:
           HUSKY: 0
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           npm i -g conventional-changelog-cli@2.2.2
           SUMMARY=$(((npx conventional-changelog -u) 2>&1) | sed "s/*/<br> */g" | sed "s/#/ /g" | tr -d '\n' || true)
@@ -95,16 +94,21 @@ jobs:
           echo "Current version: $CURRENT_VERSION_VALUE"
           echo "New version: $NEW_VERSION_VALUE"
           npx replace $CURRENT_VERSION_VALUE $NEW_VERSION_VALUE sonar-project.properties
-          git add sonar-project.properties
           echo ${{ steps.create-release.outputs.new_version }}
           echo "commit_summary=$SUMMARY" >> $GITHUB_OUTPUT
-          npx standard-version -a --skip.tag
+          npx standard-version --skip.commit --skip.tag
 
-      - name: Push new version in release branch & tag
+      - name: Create verified commit via API
+        uses: ryancyq/github-signed-commit@e9f3b28c80da7be66d24b8f501a5abe82a6b855f # v1.2.0
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          git push
+        with:
+          branch-name: ${{ steps.create-release.outputs.branch_name }}
+          commit-message: 'chore(release): v${{ steps.create-release.outputs.new_version }}'
+          files: |
+            CHANGELOG.md
+            package.json
+            sonar-project.properties
 
       - name: Create pull request into master
         uses: repo-sync/pull-request@7e79a9f5dc3ad0ce53138f01df2fad14a04831c5 # v2.12.1

--- a/.github/workflows/notion-pr-sync.yml
+++ b/.github/workflows/notion-pr-sync.yml
@@ -46,6 +46,8 @@ on:
 jobs:
   request:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # to read PR metadata for Notion sync
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
@@ -57,4 +59,4 @@ jobs:
         with:
           notionKey: ${{ secrets.NOTION_BOT_KEY }}
           notionDatabaseId: ${{ secrets.NOTION_PR_DB_ID }}
-          githubKey: ${{ secrets.PAT }}
+          githubKey: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -9,6 +9,8 @@ on:
 
 jobs:
   release:
+    permissions:
+      contents: read # GITHUB_TOKEN only needs read access
     name: Publish new release
     runs-on: ubuntu-latest
     if: (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix-release/')) && github.event.pull_request.merged == true # only merged pull requests must trigger this job
@@ -17,6 +19,14 @@ jobs:
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
         with:
           egress-policy: audit
+
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PRIVATE_KEY }}
+          permission-contents: write # to create commits, tags, and releases
 
       - name: Extract version from branch name (for release branches)
         id: extract-version
@@ -30,6 +40,7 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Set Node 16
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
@@ -39,6 +50,8 @@ jobs:
       # In order to make a commit, we need to initialize a user.
       # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
       - name: Initialize mandatory git config
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           git config user.name "GitHub actions"
           git config user.email noreply@github.com
@@ -47,8 +60,8 @@ jobs:
         id: create_release
         env:
           HUSKY: 0
-          GITHUB_TOKEN: ${{ secrets.PAT }}
-          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ secrets.PAT }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          CONVENTIONAL_GITHUB_RELEASER_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           git for-each-ref refs/tags
           ./Scripts/find-tag.sh ${{ steps.extract-version.outputs.release_version }} && git tag --delete ${{ steps.extract-version.outputs.release_version }} && git push --delete origin ${{ steps.extract-version.outputs.release_version }}


### PR DESCRIPTION
## Summary
- Migrates all PAT usages to GITHUB_TOKEN or GitHub App Token
- Adds explicit permissions at job level with comments explaining why
- Follows January 2026 security best practices
- **Simplified release workflows using API-based branch creation**
- **Replaces git push with signed commits via API for verified commits**

## Files Changed
- `.github/workflows/notion-pr-sync.yml` - Migrated to GITHUB_TOKEN
- `.github/workflows/draft-new-release.yml` - Migrated to GitHub App Token + signed commits + simplified
- `.github/workflows/draft-new-beta-release.yml` - Migrated to GitHub App Token + signed commits + simplified
- `.github/workflows/publish-new-release.yml` - Migrated to GitHub App Token

## Migration Details

| File | Token Type | Signed Commits | Reason |
|------|------------|----------------|--------|
| `notion-pr-sync.yml` | GITHUB_TOKEN | N/A | Only reads PR metadata |
| `draft-new-release.yml` | GitHub App Token | Yes | Creates verified commits for releases |
| `draft-new-beta-release.yml` | GitHub App Token | Yes | Creates verified commits for beta releases |
| `publish-new-release.yml` | GitHub App Token | N/A (tags only) | Creates tags and releases |

### Migration Pattern Evolution

1. The signed-commit action (`ryancyq/github-signed-commit`) creates commits via GitHub's GraphQL API, producing **verified commits** with the App's identity
2. This eliminates the need for many git commands: `git config`, `git add`, `git commit`, `git push`
3. The key insight is that branches must be created via GitHub API (`gh api .../git/refs`) before the signed-commit action can push to them

## Key Changes

### Latest: Simplified Branch Creation
- Removed `git config user.name/email` steps (no longer needed with signed commits)
- Removed `git checkout -b` + `git push --set-upstream` pattern
- Added API-based branch creation using `gh api repos/.../git/refs`
- Branches are now created via GitHub API before signed-commit action

### Signed Commits Fix
- Replaced `git add/commit/push` patterns with `ryancyq/github-signed-commit@v1.2.0` action
- This creates **verified commits** via GitHub API instead of unverified git push
- The signed-commit action reads files directly from filesystem (no git add needed)

### draft-new-release.yml
- Replaced `npx standard-version -a --skip.tag` + `git push` with:
  - `npx standard-version --skip.commit --skip.tag`
  - `ryancyq/github-signed-commit` action to commit CHANGELOG.md, package.json, sonar-project.properties
- Replaced git-based branch creation with GitHub API

### draft-new-beta-release.yml
- Added GitHub App Token generation step
- Fixed template injection vulnerability (github.event.inputs.beta_version -> env var)
- Replaced `git add/commit/tag/push` with:
  - `ryancyq/github-signed-commit` action to commit package.json with tag
- Replaced git-based branch creation with GitHub API

### notion-pr-sync.yml
- Added job-level `permissions: pull-requests: read`
- Replaced `secrets.PAT` with `secrets.GITHUB_TOKEN`

### publish-new-release.yml
- Migrated to GitHub App Token
- Maintains git tag + push pattern (tags are created on existing commits, not new commits)

## Security Improvements
- **Verified commits**: All file changes now create verified commits via GitHub API
- Fixed template injection vulnerability in draft-new-beta-release.yml
- Follows principle of least privilege (minimal GITHUB_TOKEN permissions)
- App Token generated early in job before any operations
- Permissions documented with inline comments
- Cleaner, more secure pattern without token-in-URL

## Test plan
- [ ] Verify notion-pr-sync workflow runs successfully on PR events
- [ ] Verify draft-new-release workflow creates release PR with verified commits
- [ ] Verify draft-new-beta-release workflow creates beta release with verified commits and tags
- [ ] Verify publish-new-release workflow publishes releases and tags correctly
- [ ] Verify created PRs trigger downstream CI workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)